### PR TITLE
Mb pgp separate files and gvcf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 # Local environment, used by Foreman
 .env
 
+# Resource file storage, reloaded if they disappear.
+# Used to store hg19.2bit for var-to-VCF conversion of PGP Harvard genomes.
+resource_files/*
+!resource_files/.keep
+
 # Scratch directories
 files/*
 scratch/*

--- a/data_processing.py
+++ b/data_processing.py
@@ -22,7 +22,7 @@ from werkzeug.contrib.fixers import ProxyFix
 from celery_worker import make_worker
 
 from data_retrieval.american_gut import create_amgut_ohdataset
-from data_retrieval.pgp_harvard import create_pgpharvard_ohdatasets
+from data_retrieval.pgp_harvard import create_pgpharvard_datafiles
 from data_retrieval.twenty_three_and_me import create_23andme_ohdataset
 from data_retrieval.go_viral import create_go_viral_ohdataset
 from data_retrieval.runkeeper import create_runkeeper_ohdatasets
@@ -177,11 +177,11 @@ def make_amgut_ohdataset(**task_params):
 
 
 @celery_worker.task
-def make_pgpharvard_ohdataset(**task_params):
+def make_pgpharvard_datafiles(**task_params):
     """
     Task to initiate retrieval of PGP Harvard data set
     """
-    create_pgpharvard_ohdatasets(**task_params)
+    create_pgpharvard_datafiles(**task_params)
 
 
 @celery_worker.task
@@ -250,7 +250,7 @@ def pgp_harvard():
         'huID' (string with PGP ID, eg 'hu1A2B3C')
     """
     task_params = json.loads(request.args['task_params'])
-    make_pgpharvard_ohdataset.delay(**task_params)
+    make_pgpharvard_datafiles.delay(**task_params)
     return 'PGP Harvard dataset started'
 
 

--- a/data_processing.py
+++ b/data_processing.py
@@ -181,7 +181,7 @@ def make_pgpharvard_datafiles(**task_params):
     """
     Task to initiate retrieval of PGP Harvard data set
     """
-    create_pgpharvard_datafiles(**task_params)
+    create_pgpharvard_datafiles(sentry=sentry, **task_params)
 
 
 @celery_worker.task

--- a/data_retrieval/files.py
+++ b/data_retrieval/files.py
@@ -1,0 +1,88 @@
+import bz2
+import gzip
+import os
+import re
+import shutil
+import tempfile
+import urlparse
+
+from boto.exception import S3ResponseError
+from boto.s3.connection import S3Connection
+import requests
+
+
+def s3_connection():
+    """
+    Get an S3 connection using environment variables.
+    """
+    key = os.getenv('AWS_ACCESS_KEY_ID')
+    secret = os.getenv('AWS_SECRET_ACCESS_KEY')
+    if not (key and secret):
+        raise Exception('You must specify AWS credentials.')
+    return S3Connection(key, secret)
+
+
+def copy_file_to_s3(bucket, keypath, filepath):
+    """
+    Copy a local file to S3.
+    """
+    s3 = s3_connection()
+    bucket = s3.get_bucket(bucket)
+    key = bucket.new_key(keypath)
+    # Override MIME type for compressed files, which AWS sets automatically.
+    # These can be erroneous and, even if correct, ome browsers try to "help",
+    # for example:
+    # - 'foo.csv.bz2' is automatically assigned 'text/csv', browser renames the
+    #    downloaded file to 'foo.csv'.
+    #  - 'foo.csv.bz2' set to type 'application/x-bzip2', browser renames the
+    #    downloaded file to 'foo.bz2'.
+    if keypath.endswith('.gz') or keypath.endswith('.bz2'):
+        key.set_metadata('Content-Type', 'application/octet-stream')
+
+    key.set_contents_from_filename(filepath)
+    print 'Setting bucket {} and key {} to contents from {}'.format(
+        bucket, keypath, filepath)
+    key.close()
+    s3.close()
+
+
+def get_remote_file(url, tempdir):
+    """
+    Get and save a remote file to temporary directory. Return filename used.
+    """
+    req = requests.get(url, stream=True)
+    orig_filename = ''
+    if 'Content-Disposition' in req.headers:
+        regex = re.match(r'attachment; filename="(.*)"$',
+                         req.headers['Content-Disposition'])
+        if regex:
+            orig_filename = regex.groups()[0]
+    if not orig_filename:
+        orig_filename = urlparse.urlsplit(req.url)[2].split('/')[-1]
+    print orig_filename
+    tempf = open(os.path.join(tempdir, orig_filename), 'wb')
+    for chunk in req.iter_content(chunk_size=512 * 1024):
+        if chunk:
+            tempf.write(chunk)
+    tempf.close()
+    return orig_filename
+
+
+def mv_tempfile_to_output(filepath, filename, **kwargs):
+    """
+    Copy a temp file to S3 or local permanent directory, then delete temp copy.
+    """
+    if 's3_key_dir' in kwargs and 's3_bucket_name' in kwargs:
+        keypath = os.path.join(kwargs['s3_key_dir'], filename)
+        copy_file_to_s3(
+            bucket=kwargs['s3_bucket_name'],
+            keypath=keypath,
+            filepath=filepath)
+        output_path = keypath
+    elif 'filedir' in kwargs:
+        output_path = os.path.join(kwargs['filedir'], filename)
+        shutil.copy(filepath, output_path)
+    else:
+        raise ValueError("Must specify S3 key & bucket, or local filedir.")
+    os.remove(filepath)
+    return output_path

--- a/data_retrieval/files.py
+++ b/data_retrieval/files.py
@@ -1,14 +1,20 @@
-import bz2
-import gzip
+from datetime import datetime
 import os
 import re
 import shutil
-import tempfile
 import urlparse
 
-from boto.exception import S3ResponseError
 from boto.s3.connection import S3Connection
 import requests
+
+
+def now_string():
+    """
+    Return the current date and time in a format suitable for a filename.
+
+    This is ISO 8601 without the optional date dashes and time colons.
+    """
+    return datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
 
 
 def s3_connection():

--- a/data_retrieval/pgp_harvard.py
+++ b/data_retrieval/pgp_harvard.py
@@ -10,11 +10,13 @@ May be used on the command line from this project's base directory, e.g.
 
    python -m data_retrieval.pgp_harvard hu43860C files
 
-...will assemble data sets for the ID "hu43860C" at:
+...assembles data sets for the ID "hu43860C" in the "files" directory, e.g.:
 
-   files/PGP-Harvard-surveys-hu43860C.json
-   files/PGP-Harvard-var-hu43860C.tsv.bz2
-   files/PGP-Harvard-var-hu43860C.vcf.bz2
+   files/PGP-Harvard-surveys-hu43860C-20160102T030405Z.json
+   files/PGP-Harvard-var-hu43860C-20160102T030405Z.tsv.bz2
+   files/PGP-Harvard-var-hu43860C-20160102T030405Z.vcf.bz2
+
+(These filenames includes a datetime stamp, January 2rd 2016 3:04:05am UTC.)
 """
 import json
 import os
@@ -28,7 +30,7 @@ import requests
 
 from bs4 import BeautifulSoup
 
-from .files import get_remote_file, mv_tempfile_to_output
+from .files import get_remote_file, mv_tempfile_to_output, now_string
 
 BASE_URL = 'https://my.pgp-hms.org'
 
@@ -183,7 +185,7 @@ def vcf_from_var(vcf_filename, tempdir, var_filepath):
 def handle_var_file(filename, tempdir, huID):
     data_files = []
     var_description = 'PGP Harvard genome, Complete Genomics var file format.'
-    new_filename = 'PGP-Harvard-var-{}.tsv.bz2'.format(huID)
+    new_filename = 'PGP-Harvard-var-{}-{}.tsv.bz2'.format(huID, now_string())
     new_filepath = os.path.join(tempdir, new_filename)
     shutil.move(os.path.join(tempdir, filename), new_filepath)
     data_files.append({
@@ -203,7 +205,7 @@ def handle_mastervarbeta_file(filename, tempdir, huID):
     data_files = []
     description = ('PGP Harvard genome, Complete Genomics masterVarBeta file '
                    'format.')
-    new_filename = 'PGP-Harvard-masterVarBeta-{}.tsv.bz2'.format(huID)
+    new_filename = 'PGP-Harvard-masterVarBeta-{}-{}.tsv.bz2'.format(huID, now_string())
     new_filepath = os.path.join(tempdir, new_filename)
     shutil.move(os.path.join(tempdir, filename), new_filepath)
     data_files.append(
@@ -217,7 +219,7 @@ def handle_mastervarbeta_file(filename, tempdir, huID):
 def make_survey_file(survey_data, tempdir, huID):
     data_files = []
     description = 'PGP Harvard survey data, JSON format.'
-    survey_filename = 'PGP-Harvard-surveys-{}.json'.format(huID)
+    survey_filename = 'PGP-Harvard-surveys-{}-{}.json'.format(huID, now_string())
     survey_filepath = os.path.join(tempdir, survey_filename)
     with open(survey_filepath, 'w') as f:
         json.dump(survey_data, f, indent=2, sort_keys=True)

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 beautifulsoup4==4.4.1
 boto==2.38.0
 celery==3.1.19
+cgivar2gvcf==0.1.5
 Flask-SSLify==0.1.5
 Flask==0.10.1
 gevent==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ billiard==3.3.0.21        # via celery
 blinker==1.4              # via raven
 boto==2.38.0
 celery==3.1.19
+cgivar2gvcf==0.1.5
 click==6.2                # via pip-tools
 first==2.0.1              # via pip-tools
 Flask-SSLify==0.1.5


### PR DESCRIPTION
Updates to PGP Harvard data import.
- Create separate files, not using a compressed tar archive.
- Import survey data as JSON if available.
- Import Complete Genomics var file, if available.
- If there's a var file, create gVCF from var file.
- Import Complete Genomics masterVarBeta file, if available.

Task update sends both old version of update data ('s3_keys') and planned new field containing s3 key, description, and tags information ('data_files'), as planned for https://github.com/PersonalGenomesOrg/open-humans/issues/320
