### PR TITLE
🔧 Avoid reprocessing 23andMe data

### DIFF
--- a/base_source.py
+++ b/base_source.py
@@ -129,11 +129,7 @@ class BaseSource(object):
 
     def coerce_file(self):
         """
-        Map remote file URLs into a local input file.
-
-        Also hash of the original filepath for remote files. This can
-        be stored as metadata in output files, then used to help determine
-        when reprocessing should be performed in the future.
+        Map remote file URLs into a local input file, if necessary.
         """
         if self.file_url and self.input_file:
             raise Exception('Run with input_file or file_url, not both')

--- a/base_source.py
+++ b/base_source.py
@@ -6,10 +6,12 @@ import os
 import re
 import shutil
 import tempfile
+import urlparse
 import zipfile
 
 from urlparse import urljoin, urlsplit
 
+import bcrypt
 import click
 import requests
 
@@ -126,6 +128,13 @@ class BaseSource(object):
                 'output_directory or S3 parameters must be provided')
 
     def coerce_file(self):
+        """
+        Map remote file URLs into a local input file.
+
+        Also hash of the original filepath for remote files. This can
+        be stored as metadata in output files, then used to help determine
+        when reprocessing should be performed in the future.
+        """
         if self.file_url and self.input_file:
             raise Exception('Run with input_file or file_url, not both')
         elif self.file_url and not self.input_file:
@@ -142,6 +151,7 @@ class BaseSource(object):
             zip_files = self.filter_archive(zip_file)
 
             if len(zip_files) != 1:
+                self.sentry_log(error_message)
                 raise ValueError(error_message)
 
             return zip_file.open(zip_files[0])
@@ -152,6 +162,7 @@ class BaseSource(object):
         elif self.input_file.endswith('.txt'):
             return open(self.input_file)
 
+        self.sentry_log(error_message)
         raise ValueError(error_message)
 
     @staticmethod
@@ -160,7 +171,7 @@ class BaseSource(object):
                 if not f.startswith('__MACOSX/')]
 
     def sentry_log(self, message):
-        message += ' Username: "{}"'.format(self.oh_username)
+        message += ' Username: "{}", Source: "{}"'.format(self.oh_username, self.source)
 
         logger.warn(message)
 
@@ -212,8 +223,7 @@ class BaseSource(object):
 
         return specified_filename
 
-    @staticmethod
-    def should_update(files):
+    def should_update(self, files):
         """
         Sources should override this method and return True if the member's
         source data needs updating.
@@ -290,11 +300,11 @@ class BaseSource(object):
                                  method='post')
 
     def run(self):
-        if not self.should_update(self.get_current_files()) and not self.force:
-            return
-
         if not self.local:
             self.update_parameters()
+
+        if not self.should_update(self.get_current_files()) and not self.force:
+            return
 
         self.coerce_file()
         self.validate_parameters()

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 -e git+https://github.com/beaugunderson/requests-respectful#egg=requests-respectful
 
 arrow==0.8.0
+bcrypt==3.1.1
 beautifulsoup4==4.5.1
 boto==2.42.0
 celery==3.1.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,17 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
--e git+https://github.com/beaugunderson/requests-respectful#egg=requests-respectful
+-e git+https://github.com/madprime/requests-respectful#egg=requests-respectful
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 arrow==0.8.0
+bcrypt==3.1.1
 beautifulsoup4==4.5.1
 billiard==3.3.0.23        # via celery
 blinker==1.4              # via raven
 boto==2.42.0
 celery==3.1.23
+cffi==1.8.3               # via bcrypt
 cgivar2gvcf==0.1.7
 click==6.6
 contextlib2==0.5.4        # via raven
@@ -33,6 +35,7 @@ nose==1.3.7
 numpy==1.11.1             # via matplotlib
 pip-tools==1.7.0
 psycopg2==2.6.2
+pycparser==2.16           # via cffi
 pyparsing==2.1.8          # via matplotlib
 python-dateutil==2.5.3    # via arrow, matplotlib
 pytz==2016.6.1            # via celery, matplotlib

--- a/sources/twenty_three_and_me/__init__.py
+++ b/sources/twenty_three_and_me/__init__.py
@@ -12,9 +12,13 @@ import logging
 import os
 import re
 import shutil
+import urlparse
 
 from cStringIO import StringIO
 from datetime import date, datetime
+
+import arrow
+import bcrypt
 
 from base_source import BaseSource
 
@@ -191,9 +195,11 @@ class TwentyThreeAndMeSource(BaseSource):
             if re.match(r'(rs|i)[0-9]+\t[1-9XYM][0-9T]?\t[0-9]+\t[ACGT\-ID][ACGT\-ID]?', next_line):
                 output.write(next_line)
             else:
-                bad_format = True
-
-                logger.warn('bad format: "%s"', next_line)
+                # Only report this type of format issue once.
+                if not bad_format:
+                    bad_format = True
+                    self.sentry_log('23andMe body did not conform to expected format.')
+                    logger.warn('Bad format: "%s"', next_line)
 
             try:
                 next_line = input_file.next()
@@ -205,6 +211,38 @@ class TwentyThreeAndMeSource(BaseSource):
 
         return output
 
+    def should_update(self, files):
+        """
+        Reprocess only if source file has changed.
+
+        We store a hash of the original filepath as metadata and check this.
+        Update is deemed unnecessary if (a) processed files exist, (b) they
+        have recorded orig_file_hash, (c) we verify these all match a hash of
+        the source file path for this task (from self.file_url).
+        """
+        if not files:
+            return True
+        for file_data in files:
+            try:
+                orig_file_hash = file_data['metadata']['orig_file_hash']
+            except KeyError:
+                return True
+            if not self.same_orig_file(orig_file_hash):
+                return True
+        logger.info('Update unnecessary for user "{}", source "{}".'.format(
+            self.oh_username, self.source))
+        return False
+
+    def same_orig_file(self, orig_file_hash):
+        """
+        Check hashed self.file_url path against stored orig_file_hash.
+        """
+        if not self.file_url:
+            return False
+        url_path = str(urlparse.urlparse(self.file_url).path)
+        new_hash = bcrypt.hashpw(url_path, str(orig_file_hash))
+        return orig_file_hash == new_hash
+
     def create_files(self):
         """
         Create Open Humans Dataset from uploaded 23andme full genotyping data
@@ -215,6 +253,11 @@ class TwentyThreeAndMeSource(BaseSource):
         """
         if not self.input_file:
             raise Exception('Run with either input_file or file_url')
+
+        new_hash = ''
+        if self.file_url:
+            orig_path = urlparse.urlparse(self.file_url).path
+            new_hash = bcrypt.hashpw(str(orig_path), bcrypt.gensalt())
 
         filename_base = '23andMe-genotyping'
 
@@ -236,6 +279,8 @@ class TwentyThreeAndMeSource(BaseSource):
                     'description':
                         '23andMe full genotyping data, original format',
                     'tags': ['23andMe', 'genotyping'],
+                    'orig_file_hash': new_hash,
+                    'creation_date': arrow.get().format(),
                 },
             })
 
@@ -252,5 +297,7 @@ class TwentyThreeAndMeSource(BaseSource):
                 'metadata': {
                     'description': '23andMe full genotyping data, VCF format',
                     'tags': ['23andMe', 'genotyping', 'vcf'],
+                    'orig_file_hash': new_hash,
+                    'creation_date': arrow.get().format(),
                 },
             })

--- a/sources/twenty_three_and_me/__init__.py
+++ b/sources/twenty_three_and_me/__init__.py
@@ -236,6 +236,9 @@ class TwentyThreeAndMeSource(BaseSource):
     def same_orig_file(self, orig_file_hash):
         """
         Check hashed self.file_url path against stored orig_file_hash.
+
+        The path in an original source file URL are expected to be unique, as
+        we store them with a UUID.
         """
         if not self.file_url:
             return False


### PR DESCRIPTION
We want to avoid reprocessing the same data if it's not needed.

To determine this, we store a hash of the pre-processed file's path as
metadata in processed files. Check this to decide when reprocessing is
unnecessary (because the source file is the same).

The source files (uploaded by users) include a UUID in their path,
so any given upload should produce a unique hash.
